### PR TITLE
Fix for parsing error when the output of the info command has empty line...

### DIFF
--- a/ZenPacks/chudler/redis/lib/redis/client.py
+++ b/ZenPacks/chudler/redis/lib/redis/client.py
@@ -126,6 +126,9 @@ def parse_info(response):
                 sub_dict[k] = v
         return sub_dict
     for line in response.splitlines():
+        line = line.strip()
+        if not line or line.startswith('#'): continue
+
         key, value = line.split(':')
         try:
             info[key] = int(value)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # or saved.  Do not modify them directly here.
 # NB: PACKAGES is deprecated
 NAME = "ZenPacks.chudler.redis"
-VERSION = "1.0.1"
+VERSION = "1.0.2"
 AUTHOR = "Colin Hudler"
 LICENSE = "GPLv2"
 NAMESPACE_PACKAGES = ['ZenPacks', 'ZenPacks.chudler']


### PR DESCRIPTION
...s or comment lines
